### PR TITLE
updating kustomize to a version which supports `go install`

### DIFF
--- a/l5-operator/Makefile
+++ b/l5-operator/Makefile
@@ -144,7 +144,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest


### PR DESCRIPTION
- older versions of kustomize do not support `go install`
- updating to the latest version of kustomize


Signed-off-by: Adam D. Cornett <adc@redhat.com>