### PR TITLE
add status conditions

### DIFF
--- a/api/v1/bestie_types.go
+++ b/api/v1/bestie_types.go
@@ -42,6 +42,17 @@ type BestieSpec struct {
 	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 }
 
+// Status Condition Types.
+const (
+	DatabaseReady   string = "DatabaseReady"
+	DatabaseSeeded  string = "DatabaseSeeded"
+	DeploymentReady string = "DeploymentReady"
+	ServiceCreated  string = "ServiceCreated"
+	HPACreated      string = "HPACreated"
+	RouteCreated    string = "RouteCreated"
+	IngressCreated  string = "IngressCreated"
+)
+
 // BestieStatus defines the observed state of Bestie.
 type BestieStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster.
@@ -52,6 +63,13 @@ type BestieStatus struct {
 
 	// Current version deployed
 	AppVersion string `json:"appversion,omitempty"`
+
+	// The operators status conditions
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:io.kubernetes.conditions"}
+	Conditions []metav1.Condition `json:"conditions"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the pets v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=pets.bestie.com
+// +kubebuilder:object:generate=true
+// +groupName=pets.bestie.com
 package v1
 
 import (

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -111,6 +112,13 @@ func (in *BestieStatus) DeepCopyInto(out *BestieStatus) {
 		in, out := &in.PodStatus, &out.PodStatus
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/config/crd/bases/pets.bestie.com_besties.yaml
+++ b/config/crd/bases/pets.bestie.com_besties.yaml
@@ -60,6 +60,79 @@ spec:
               appversion:
                 description: Current version deployed
                 type: string
+              conditions:
+                description: The operators status conditions
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               podstatus:
                 description: List of pods, their status and the image they use
                 items:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opdev/l5-operator
-  newTag: v0.0.2
+  newTag: v0.0.1

--- a/config/resources/postgrescluster.yaml
+++ b/config/resources/postgrescluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.41-4
       repos:
       - name: repo1
         volume:
@@ -15,7 +15,7 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.6-1
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0
   instances:
   - dataVolumeClaimSpec:
       accessModes:
@@ -26,4 +26,4 @@ spec:
     name: instance1
     replicas: 1
   port: 5432
-  postgresVersion: 13
+  postgresVersion: 14

--- a/internal/bestie_errors/errors.go
+++ b/internal/bestie_errors/errors.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,3 +19,4 @@ import "errors"
 
 var InvalidMaxReplicasValue = errors.New("MaxReplicas should be greater than deployment size to avoid contention between the deployment and horizontal pod autoscaling controllers")
 var InvalidDeploymentSizeValue = errors.New("Deployment size should be less than MaxReplicas to avoid contention between the deployment and horizontal pod autoscaling controllers")
+var ErrWhenRefreshingBestieResource = errors.New("Error when retrieving most recent copy of the bestie custom resource")

--- a/internal/sub_reconcilers/conditions.go
+++ b/internal/sub_reconcilers/conditions.go
@@ -1,0 +1,86 @@
+/*
+Copyright The L5 Operator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sub_reconcilers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	petsv1 "github.com/opdev/l5-operator-demo/api/v1"
+)
+
+func NewDatabaseCreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.DatabaseReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  "PostgresClusterCreated",
+		Message: "Created PostgresCluster resource",
+	}
+}
+
+func NewDatabaseSeededCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.DatabaseSeeded,
+		Status:  metav1.ConditionFalse,
+		Reason:  "DatabaseSeedJobCreated",
+		Message: "Database seed job has been created",
+	}
+}
+
+func NewDeploymentCreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.DeploymentReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  "DeploymentCreated",
+		Message: "Created Deployment resource",
+	}
+}
+
+func NewServiceCreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.ServiceCreated,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ServiceCreated",
+		Message: "The Service has been created",
+	}
+}
+
+func NewHPACreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.HPACreated,
+		Status:  metav1.ConditionTrue,
+		Reason:  "HPACreated",
+		Message: "A horizontal pod autoscaling object has been created",
+	}
+}
+
+func NewRouteCreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.RouteCreated,
+		Status:  metav1.ConditionTrue,
+		Reason:  "RouteCreated",
+		Message: "The Route has been created",
+	}
+}
+
+func NewIngressCreatedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    petsv1.IngressCreated,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ServiceCreated",
+		Message: "The Ingress has been created",
+	}
+}

--- a/internal/sub_reconcilers/reconcile_route.go
+++ b/internal/sub_reconcilers/reconcile_route.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	networkv1 "k8s.io/api/networking/v1"
@@ -54,17 +56,27 @@ func (r *RouteReconciler) Reconcile(ctx context.Context, bestie *petsv1.Bestie) 
 	}
 	r.Log.WithValues("route", logInfo)
 	r.Log.Info("deploy route or service if openshift or vanilla k8s")
-	// If the cluster is OpenShift, add a route, else add an ingress.
+	// If the cluster is OpenShift, add a route, otherwise add an ingress.
 	if util.IsRouteAPIAvailable() {
-		// utilruntime.Must(routev1.AddToScheme(runtime.NewScheme()))
 		route := &routev1.Route{}
 		err := r.client.Get(ctx, types.NamespacedName{Name: bestie.Name + "-route", Namespace: bestie.Namespace}, route)
 		if err != nil && errors.IsNotFound(err) {
 			r.Log.Info("Creating a new route for bestie")
 			fileName := "config/resources/bestie-route.yaml"
-			err := r.applyManifests(ctx, bestie, route, fileName)
+			err = r.applyManifests(ctx, bestie, route, fileName)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("error during Manifests apply - %w", err)
+				return ctrl.Result{}, fmt.Errorf("error during manifests apply - %w", err)
+			}
+			err = util.RefreshCustomResource(ctx, r.client, bestie)
+			if err != nil {
+				r.Log.Error(err, "Unable to refresh bestie custom resource")
+				return ctrl.Result{}, err
+			}
+			meta.SetStatusCondition(&bestie.Status.Conditions, NewRouteCreatedCondition())
+			err = r.client.Status().Update(ctx, bestie)
+			if err != nil {
+				r.Log.Error(err, "Unable to set route created status condition")
+				return ctrl.Result{}, err
 			}
 		}
 	} else {
@@ -77,8 +89,20 @@ func (r *RouteReconciler) Reconcile(ctx context.Context, bestie *petsv1.Bestie) 
 			err = r.applyManifests(ctx, bestie, ingress, fileName)
 			if err != nil {
 				r.Log.Error(err, "Failed to get ingress.")
-				return ctrl.Result{Requeue: true}, err
+				return ctrl.Result{}, fmt.Errorf("error during manifests apply - %w", err)
 			}
+			err = util.RefreshCustomResource(ctx, r.client, bestie)
+			if err != nil {
+				r.Log.Error(err, "Unable to refresh bestie custom resource")
+				return ctrl.Result{}, err
+			}
+			meta.SetStatusCondition(&bestie.Status.Conditions, NewIngressCreatedCondition())
+			err = r.client.Status().Update(ctx, bestie)
+			if err != nil {
+				r.Log.Error(err, "Unable to update ingress status condition")
+				return ctrl.Result{}, err
+			}
+
 		}
 	}
 	return ctrl.Result{}, nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -93,4 +95,17 @@ func verifyOpenShiftCluster(group string, version string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+func RefreshCustomResource(ctx context.Context, client client.Client, bestie *petsv1.Bestie) error {
+	Log := ctrllog.FromContext(ctx)
+	err := client.Get(ctx, types.NamespacedName{
+		Namespace: bestie.Namespace,
+		Name:      bestie.Name,
+	}, bestie)
+	if err != nil {
+		Log.Error(err, "Unable to refresh bestie resource")
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Added status conditions as an example. Usage of status conditions is now part of the memcached operator sample which is part of operator sdk so this has since become redundant as an example. However it does help a user understand what the operator is doing so this is still relevant.

```
status:
  appversion: "1.3"
  conditions:
  - lastTransitionTime: "2023-03-08T17:53:08Z"
    message: Postgres cluster has ready replicas
    reason: HasReadyReplicas
    status: "True"
    type: DatabaseReady
  - lastTransitionTime: "2023-03-08T17:52:37Z"
    message: The Service has been created
    reason: ServiceCreated
    status: "True"
    type: ServiceCreated
  - lastTransitionTime: "2023-03-08T17:52:37Z"
    message: The Route has been created
    reason: RouteCreated
    status: "True"
    type: RouteCreated
  - lastTransitionTime: "2023-03-08T17:53:23Z"
    message: Database seed job completed successfully
    reason: SeedJobCompleted
    status: "True"
    type: DatabaseSeeded
  - lastTransitionTime: "2023-03-08T17:53:54Z"
    message: Deployment has min ready replicas
    reason: HasMinReadyReplicas
    status: "True"
    type: DeploymentReady
  - lastTransitionTime: "2023-03-08T17:53:24Z"
    message: A horizontal pod autoscaling object has been created
    reason: HPACreated
    status: "True"
    type: HPACreated
  podstatus:
  - 'bestie-app-77d6549685-gpx5g : Running : quay.io/opdev/bestie:1.3'
  - 'bestie-app-77d6549685-s9s4m : Running : quay.io/opdev/bestie:1.3'
  - 'bestie-app-77d6549685-x5lzl : Running : quay.io/opdev/bestie:1.3'
```