### PR TITLE
example showing creation of events

### DIFF
--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the pets v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=pets.bestie.com
+// +kubebuilder:object:generate=true
+// +groupName=pets.bestie.com
 package v1
 
 import (

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opdev/l5-operator
-  newTag: v0.0.2
+  newTag: v0.0.1


### PR DESCRIPTION
Emit an event when the reconciler is triggered. This is mainly to show how the event recorder can be consumed since this example was removed in newer versions of the kubebuilder book.